### PR TITLE
Restrict drag to grip handle on prompt edit

### DIFF
--- a/pages/prompt/prompt.js
+++ b/pages/prompt/prompt.js
@@ -1947,7 +1947,7 @@ function renderEdit(idx, isNew = false) {
   /*━━━━━━━━━━ 6. プロンプト行生成 ━━━━━━━━━━*/
   function addField(text = "", enabled = true) {
     const row = ce("div", "prompt-field");
-    row.draggable = true;
+    row.draggable = false; // ドラッグ開始はグリップアイコンのみ
 
     /* --- 改善されたDnD handlers --- */
     let dragStartIndex = null;
@@ -2119,6 +2119,11 @@ function renderEdit(idx, isNew = false) {
                     rows="4">${text}</textarea>
         </div>
       </div>`;
+    // グリップアイコンのみドラッグ可能に設定
+    const grip = row.querySelector(".grip-icon");
+    if (grip) {
+      grip.draggable = true;
+    }
     row.querySelector(".btn-remove-field").onclick = async () => {
       console.log("削除ボタンがクリックされました");
 
@@ -2235,7 +2240,8 @@ function renderEdit(idx, isNew = false) {
       }
 
       // ドラッグ＆ドロップの初期化を確実に行う
-      if (row.draggable) {
+      const gripCheck = row.querySelector(".grip-icon");
+      if (gripCheck && gripCheck.draggable) {
         console.log("[DND] 新しいフィールドのドラッグ＆ドロップを初期化:", row);
       }
     }, 50);

--- a/pages/prompt/prompt.js
+++ b/pages/prompt/prompt.js
@@ -1953,7 +1953,12 @@ function renderEdit(idx, isNew = false) {
     let dragStartIndex = null;
 
     row.addEventListener("dragstart", (e) => {
-      console.log("[DND] ドラッグ開始");
+      console.log("[DND] dragstart from element:", e.target);
+      if (!e.target.closest(".grip-icon")) {
+        console.log("[DND] dragstart canceled - not grip icon");
+        e.preventDefault();
+        return;
+      }
       dragStartIndex = [...wrap.children].indexOf(row);
       e.dataTransfer.setData("text/plain", dragStartIndex.toString());
       e.dataTransfer.effectAllowed = "move";
@@ -2209,6 +2214,8 @@ function renderEdit(idx, isNew = false) {
       // 新しく追加されたtextareaに自動リサイズ機能を適用
       const newTextarea = row.querySelector(".prompt-field-textarea");
       if (newTextarea) {
+        newTextarea.draggable = false;
+        console.log("[DND] disable dragging for textarea");
         // 自動リサイズのイベントリスナーを追加
         newTextarea.addEventListener("input", () => autoResize(newTextarea));
         newTextarea.addEventListener("paste", () =>

--- a/pages/prompt/prompt.js
+++ b/pages/prompt/prompt.js
@@ -1947,7 +1947,8 @@ function renderEdit(idx, isNew = false) {
   /*━━━━━━━━━━ 6. プロンプト行生成 ━━━━━━━━━━*/
   function addField(text = "", enabled = true) {
     const row = ce("div", "prompt-field");
-    row.draggable = false; // ドラッグ開始はグリップアイコンのみ
+    // デフォルトでドラッグ可能にし、ハンドル以外からの開始をブロック
+    row.draggable = true;
 
     /* --- 改善されたDnD handlers --- */
     let dragStartIndex = null;


### PR DESCRIPTION
## Summary
- restrict prompt field drag events to the grip icon only
- mark grip icon as draggable and check it when initializing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e02cd772083278ec3ef904ae3537c